### PR TITLE
Make sure there's only one slash as path separator

### DIFF
--- a/digdag_client.gemspec
+++ b/digdag_client.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/digdag_client/version', __FILE__)
 
 Gem::Specification.new do |spec|
 
-  spec.add_runtime_dependency('faraday', ['~> 0.12'])
+  spec.add_runtime_dependency('faraday', ['~>0.9'])
   spec.add_runtime_dependency('faraday_middleware', ['~> 0.11'])
 
   spec.name          = "digdag_client"

--- a/lib/digdag_client/client/log.rb
+++ b/lib/digdag_client/client/log.rb
@@ -16,7 +16,7 @@ module Digdag
           options[:task] = params[:task]
         end
 
-        get("/logs/#{attempt_id}/files", params)
+        get("logs/#{attempt_id}/files", params)
       end
 
       def get_file(attempt_id, file_name)

--- a/lib/digdag_client/client/version.rb
+++ b/lib/digdag_client/client/version.rb
@@ -2,13 +2,13 @@ module Digdag
   class Client
     module Version
       def get_version
-        get('/version')
+        get('version')
       end
 
       def check_client_version(params={})
         options = {}
         options[:client] = params[:client]
-        get('/version/check', options)
+        get('version/check', options)
       end
     end
   end

--- a/lib/digdag_client/client/workflow.rb
+++ b/lib/digdag_client/client/workflow.rb
@@ -7,7 +7,7 @@ module Digdag
         options[:project] = params[:project]
         options[:name] = params[:name]
 
-        get('/workflow', options)
+        get('workflow', options)
       end
 
       def get_workflows(params={})
@@ -20,11 +20,11 @@ module Digdag
           options[:last_id] = params[:last_id]
         end
 
-        get('/workflows', options)["workflows"]
+        get('workflows', options)["workflows"]
       end
 
       def get_workflow(id)
-        get("/workflows/#{id}")
+        get("workflows/#{id}")
       end
     end
   end


### PR DESCRIPTION
In Ruby -2.4, URI will remove the double slash, however it's not the case in Ruby 2.5.

**Examples**
```rb
# 2.3.1
> URI.parse('http://a/b//c') + '.'
=> #<URI::HTTP http://a/b/>
> URI.join("http://test//", "a").to_s
=> "http://test/a"

# 2.4.5
> URI.parse('http://a/b//c') + '.'
=> #<URI::HTTP http://a/b/>
> URI.join("http://test//", "a").to_s
=> "http://test/a"

# 2.5.3
> URI.parse('http://a/b//c') + '.'
=> #<URI::HTTP http://a/b//>
> URI.join("http://test//", "a").to_s
=> "http://test//a"
```
