### PR TITLE
Delete duplicated method (Schedule#get_schedules)

### DIFF
--- a/lib/digdag_client/client/schedule.rb
+++ b/lib/digdag_client/client/schedule.rb
@@ -5,10 +5,6 @@ module Digdag
         # TODO
       end
 
-      def get_schedules
-        # TODO
-      end
-
       def skip_schedule
         # TODO
       end


### PR DESCRIPTION
Ruby warnings:

```
.../lib/digdag_client/client/schedule.rb:8: warning: method redefined; discarding old get_schedules
.../lib/digdag_client/client/schedule.rb:4: warning: previous definition of get_schedules was here
```
